### PR TITLE
Use `_console` instead of `console`

### DIFF
--- a/src/ti-console.js
+++ b/src/ti-console.js
@@ -29,18 +29,18 @@ _console.timeEnd = function(label) {
 	}
 
 	var duration = now() - time;
-	console.log(label + ": " + duration + "ms");
+	_console.log(label + ": " + duration + "ms");
 };
 
 _console.trace = function() {
 	var err = new Error();
 	err.name = "Trace";
 	err.message = util.format.apply(null, arguments);
-	console.error(err.stack);
+	_console.error(err.stack);
 };
 
 _console.dir = function(object) {
-	console.log(util.inspect(object) + "\n");
+	_console.log(util.inspect(object) + "\n");
 };
 
 _console.assert = function(expression) {


### PR DESCRIPTION
So that we don’t have to rely on external `console.log` presence.
