### PR TITLE
Require `assert` only when necessary

### DIFF
--- a/src/ti-console.js
+++ b/src/ti-console.js
@@ -1,5 +1,4 @@
 var util = require("util");
-var assert = require("assert");
 var now = require("date-now");
 
 var _console = {};
@@ -46,7 +45,7 @@ _console.dir = function(object) {
 _console.assert = function(expression) {
 	if (!expression) {
 		var arr = Array.prototype.slice.call(arguments, 1);
-		assert.ok(false, util.format.apply(null, arr));
+		require("assert").ok(false, util.format.apply(null, arr));
 	}
 };
 


### PR DESCRIPTION
This solves some funny cyclic issues because `util` and `assert` use `ti-console` in titaniumifier.

I couldn’t get a reproducible test case, also because this is mostly a browserify/titaniumifier related problem therefore I’d need to have a different build flow just to test this limit scenario.

/cc @tonylukasavage
